### PR TITLE
Add stackable items to Cairn

### DIFF
--- a/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
+++ b/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
@@ -54,7 +54,7 @@
     const restoreAbility = () => {
         // restore all abilities to max
         for (const AS in character.ability_scores) {
-            character.ability_scores[AS].current = character.ability_scores[AS].max;           
+            character.ability_scores[AS].current = character.ability_scores[AS].max;
         }
         $modifyCharacter();
     }
@@ -74,7 +74,7 @@
     }
 
     $: filledSlotsCount = character.inventory.reduce(
-        (acc, item) => acc + (item.bulky ? 2 : 1),
+        (acc, item) => acc + (item.stacks ? 0 : item.bulky ? 2 : 1),
         0
     );
 
@@ -91,8 +91,8 @@
         {#each Object.keys(character.ability_scores) as AS}
         <div class="ability-score">
             <div class="ability-score-values">
-                <BoxWithMax label={AS} 
-                    bind:currentValue={character.ability_scores[AS].current} 
+                <BoxWithMax label={AS}
+                    bind:currentValue={character.ability_scores[AS].current}
                     bind:maxValue={character.ability_scores[AS].max}
                     sendable
                     sendFce={() => sendAbilitySave(AS)}
@@ -116,7 +116,7 @@
             {filledSlotsCount}
         </RowBoxWithLabel>
     </div>
-    
+
     <div class="coins">
         {#each Object.keys(character.coins) as coinType}
             <InPlaceEditBox bind:value={character.coins[coinType]} boxLabel={coinType} valueFontSize="1.2em" editWidth="2em" editHeight="2em" />
@@ -136,7 +136,7 @@
     </div>
 
     <div class="deprived">
-        <RowBoxWithLabel 
+        <RowBoxWithLabel
             label='Deprived'
             clickable
             onClickFn={() => { character.deprived = !character.deprived; $modifyCharacter() }}
@@ -154,23 +154,23 @@
     </BoxWithList>
 
     <div class="macros">
-        <SimpleButton value='Quick rest' 
+        <SimpleButton value='Quick rest'
             icon="mdi:beer"
-            iconWidth='1.25em' 
+            iconWidth='1.25em'
             onClickFn={() => characterRest()}
         />
-        <SimpleButton value='Full night' 
-            icon="mdi:bed" 
+        <SimpleButton value='Full night'
+            icon="mdi:bed"
             iconWidth='1.25em'
             onClickFn={() => characterSleep()}
         />
         <SimpleButton value='Week’s rest'
-            icon="mdi:bottle-tonic-plus" 
+            icon="mdi:bottle-tonic-plus"
             iconWidth='1.25em'
             onClickFn={() => restoreAbility()}
         />
-        <SimpleButton value='Add fatigue' 
-            icon="mdi:sleep" 
+        <SimpleButton value='Add fatigue'
+            icon="mdi:sleep"
             iconWidth='1.25em'
             onClickFn={() => addFatigue()}
         />
@@ -185,11 +185,11 @@
 <style>
 
     tab-container {
-        display: grid; 
-        grid-template-columns: 1fr 1fr 1fr 1.5fr 1fr 0.5fr 1fr 1fr 1fr; 
-        grid-template-rows: 1fr 0.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 0.5fr; 
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr 1.5fr 1fr 0.5fr 1fr 1fr 1fr;
+        grid-template-rows: 1fr 0.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 0.5fr;
         gap: 0.75em;
-        grid-template-areas: 
+        grid-template-areas:
             "character-basic-info character-basic-info character-basic-info character-basic-info character-basic-info character-basic-info traits traits traits"
             "ability-scores ability-scores ability-scores hp deprived coins traits traits traits"
             "ability-scores ability-scores ability-scores hp armor coins traits traits traits"
@@ -201,21 +201,21 @@
             "macros macros macros inventory inventory inventory notes notes notes"
             "macros macros macros inventory inventory inventory notes notes notes"
             "macros macros macros inventory inventory inventory notes notes notes"
-            "macros macros macros char-sheet-menu char-sheet-menu char-sheet-menu notes notes notes"; 
+            "macros macros macros char-sheet-menu char-sheet-menu char-sheet-menu notes notes notes";
     }
 
     :global(.cairn-character .box-label) {
         font-size: 0.9em;
     }
 
-    .character-basic-info { grid-area: character-basic-info; 
+    .character-basic-info { grid-area: character-basic-info;
         margin: 0.75em 0em 0em 0.75em;
         display: flex;
         flex-direction: row;
         gap: 0.5em;
     }
 
-    .ability-scores { grid-area: ability-scores; 
+    .ability-scores { grid-area: ability-scores;
         display: flex;
         flex-direction: column;
         gap: 0.5em;
@@ -254,7 +254,7 @@
         gap: 0.25em;
     }
 
-    .armor { grid-area: armor; 
+    .armor { grid-area: armor;
         display: flex;
         justify-content: center;
         gap: 0.5em;
@@ -262,19 +262,19 @@
 
     .hp { grid-area: hp; }
 
-    .deprived { grid-area: deprived; 
+    .deprived { grid-area: deprived;
         display: flex;
         justify-content: center;
     }
 
-    .slots { grid-area: slots; 
+    .slots { grid-area: slots;
         display: flex;
         justify-content: space-evenly;
         gap: 0.5em;
         white-space: nowrap;
     }
 
-    .coins { grid-area: coins; 
+    .coins { grid-area: coins;
         display: flex;
         flex-direction: column;
         justify-content: center;

--- a/src/client/src/components/Game/CharacterSheet/Cairn/ItemDetailCairn.svelte
+++ b/src/client/src/components/Game/CharacterSheet/Cairn/ItemDetailCairn.svelte
@@ -28,7 +28,7 @@
     let oldTypeIndex = itemTypeIndex;
 
     $: itemIcon = itemTypeIcons[item.type];
-    
+
     $: if (itemTypeIndex !== oldTypeIndex && item.type !== 'fatigue') {
         oldTypeIndex = Object.keys(itemTypeIcons).indexOf(item.type);
         item.type = Object.keys(itemTypeIcons)[itemTypeIndex] ?? item.type;
@@ -66,8 +66,8 @@
                 <InPlaceEdit bind:value={item.name} editWidth={editWidth} editHeight={editHeight} on:submit={() => onSubmitFn()}/>
             </div>
             <div class="item-bulky">
-                <sendable on:click={() => { item.bulky = !item.bulky; onSubmitFn();}} on:keyup={() => {}}>
-                    <Icon class="medi-icon" icon="{item.bulky ? 'mdi:weight': 'mdi:feather'}" />
+                <sendable on:click={() => {(!item.stacks && !item.bulky) ? item.bulky = true : (!item.stacks && item.bulky) ? (item.stacks = true, item.bulky = false) : (item.stacks = false, item.bulky = false); onSubmitFn();}} on:keyup={() => {}}>
+                    <Icon class="medi-icon" icon="{item.stacks ? 'mid:card-multiple' : item.bulky ? 'mdi:weight': 'mdi:feather'}" />
                 </sendable>
             </div>
             <sendable class="item-menu" on:click={() => { isOpen = !isOpen }} on:keyup={() => {}}>
@@ -108,60 +108,60 @@
     .item-main-container {
         background-color: var(--clr-box-bg-light);
     }
-    
+
     .striped {
-        background: repeating-linear-gradient( 45deg, 
-            var(--clr-box-bg-light), 
-            var(--clr-box-bg-light) 10px, 
-            var(--clr-accent-darker) 10px, 
-            var(--clr-accent-darker) 20px 
+        background: repeating-linear-gradient( 45deg,
+            var(--clr-box-bg-light),
+            var(--clr-box-bg-light) 10px,
+            var(--clr-accent-darker) 10px,
+            var(--clr-accent-darker) 20px
         );
     }
 
     .fatigue {
-        display: grid; 
-        grid-template-columns: 1fr 20fr 2fr; 
-        grid-template-rows: 2fr; 
+        display: grid;
+        grid-template-columns: 1fr 20fr 2fr;
+        grid-template-rows: 2fr;
         gap: 0.5em;
         padding: 0.5em 0em;
         grid-template-areas: ". fatigue-title fatigue-remove"
     }
 
-    .fatigue-title { grid-area: fatigue-title; 
+    .fatigue-title { grid-area: fatigue-title;
         font-weight: var(--semi-bold);
     }
 
-    .fatigue-remove { grid-area: fatigue-remove; 
+    .fatigue-remove { grid-area: fatigue-remove;
         justify-content: center;
     }
 
     .item-summary {
-        display: grid; 
-        grid-template-columns: 1fr 1fr 20fr 1fr 1fr; 
-        grid-template-rows: 2fr; 
+        display: grid;
+        grid-template-columns: 1fr 1fr 20fr 1fr 1fr;
+        grid-template-rows: 2fr;
         gap: 0.5em;
         padding: 0.5em 0em;
         grid-template-areas: "item-type-icon . item-name item-bulky item-menu"
     }
 
-    .item-type-icon { grid-area: item-type-icon; 
+    .item-type-icon { grid-area: item-type-icon;
         margin-left: 0.5em;
     }
 
-    .item-bulky { grid-area: item-bulky; 
+    .item-bulky { grid-area: item-bulky;
         border-right: 1px solid var(--clr-text);
         padding-right: 0.5em;
         gap: 0.25em;
     }
 
-    .item-name { grid-area: item-name; 
+    .item-name { grid-area: item-name;
         font-size: 1.1em;
         font-weight: 400;
         font-family: Quicksand;
         text-align: center;
     }
 
-    .item-menu { grid-area: item-menu; 
+    .item-menu { grid-area: item-menu;
         margin-right: 0.5em;
     }
 

--- a/src/client/src/components/Game/CharacterSheet/Cairn/SpecificSettingsCairn.svelte
+++ b/src/client/src/components/Game/CharacterSheet/Cairn/SpecificSettingsCairn.svelte
@@ -17,16 +17,16 @@
     let statRollID: string = '';
 
     let stats = [
-        { name: 'age', formula: '2d20+10' }, 
+        { name: 'age', formula: '2d20+10' },
         { name: 'HP', formula: '1d6' },
         { name: 'gold', formula: '3d6' }
     ];
 
     const getRandomArmor = (): ItemCairn | undefined => {
         const armor = [
-            ...Array(3).fill(undefined), 
-            ...Array(11).fill('Brigandine (1 Armor, bulky)'), 
-            ...Array(5).fill('Chainmail (2 Armor, bulky)'), 
+            ...Array(3).fill(undefined),
+            ...Array(11).fill('Brigandine (1 Armor, bulky)'),
+            ...Array(5).fill('Chainmail (2 Armor, bulky)'),
             'Plate (3 Armor, bulky)'
         ].random();
 
@@ -65,7 +65,7 @@
 
     const getRandomItem = (rollTable: string[]) => {
         const item = rollTable.random();
-        return { name: item, type: 'item', bulky: item.includes('bulky')}
+        return { name: item, type: 'item', bulky: item.includes('bulky'), stacks: item.includes('stacks')}
     }
 
     const getBonusItem = () => {
@@ -79,7 +79,7 @@
 
     const getRandomInventory = (): ItemCairn[] =>  {
         let items: ItemCairn[] | undefined = [
-            { name: 'Torch', type: 'item' }, 
+            { name: 'Torch', type: 'item' },
             { name: 'Three days’ rations', type: 'item'},
             getRandomArmor(),
             getRandomWeapon(),
@@ -143,7 +143,7 @@
             }
 
             const idTag = incomingMessage.messageID.slice(0, 3);
-        
+
             if (Object.keys(character.ability_scores).includes(idTag)){
                 character.ability_scores[idTag].current = character.ability_scores[idTag].max = incomingMessage.rollResult.total.toString();
                 $modifyCharacter();

--- a/src/client/src/interfaces/Cairn/CharacterCairn.ts
+++ b/src/client/src/interfaces/Cairn/CharacterCairn.ts
@@ -22,6 +22,7 @@ export interface ItemCairn {
     name?: string,
     type: string,
     bulky?: boolean,
+    stacks?: boolean,
     damage?: string,
     armor?: string,
     description?: string

--- a/src/enum/cairn/TOOLS.ts
+++ b/src/enum/cairn/TOOLS.ts
@@ -1,1 +1,1 @@
-export const TOOLS = ['Bellows', 'Bucket', 'Caltrops', 'Chalk', 'Chisel', 'Cook Pots', 'Crowbar', 'Drill (Manual)', 'Fishing Rod', 'Glue', 'Grease', 'Hammer', 'Hour Glass', 'Metal File', 'Nails', 'Net', 'Saw', 'Sealant', 'Shovel', 'Tongs'];
+export const TOOLS = ['Bellows', 'Bucket (stacks)', 'Caltrops', 'Chalk', 'Chisel', 'Cook Pots', 'Crowbar', 'Drill (Manual)', 'Fishing Rod', 'Glue (stacks)', 'Grease', 'Hammer', 'Hour Glass', 'Metal File (stacks)', 'Nails (stacks)', 'Net (stacks)', 'Saw', 'Sealant', 'Shovel', 'Tongs'];

--- a/src/enum/cairn/TRINKETS.ts
+++ b/src/enum/cairn/TRINKETS.ts
@@ -1,1 +1,1 @@
-export const TRINKETS = ['Bottle', 'Card Deck', 'Dice Set', 'Face Paint', 'Fake Jewels', 'Horn', 'Incense', 'Instrument', 'Lens', 'Marbles', 'Mirror', 'Perfume', 'Quill & Ink', 'Salt Pack', 'Small Bell', 'Soap', 'Sponge', 'Tar Pot', 'Twine', 'Whistle'];
+export const TRINKETS = ['Bottle', 'Card Deck (stacks)', 'Dice Set (stacks)', 'Face Paint', 'Fake Jewels (stacks)', 'Horn', 'Incense (stacks)', 'Instrument', 'Lens', 'Marbles (stacks)', 'Mirror', 'Perfume', 'Quill & Ink', 'Salt Pack (stacks)', 'Small Bell', 'Soap (stacks)', 'Sponge', 'Tar Pot', 'Twine (stacks)', 'Whistle'];


### PR DESCRIPTION
Fixes #78

This updates certain Tools and Trinkets to have `(stacks)` in their name. This will prevent them from taking up a slot.

Instead of rendering the icon for bulky/feather, add a third state using card-multiple icon to represent stacking.

Removed some trailing whitespaces. I can revert this if you'd like.