### PR TITLE
Fix resting and inventory management

### DIFF
--- a/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
+++ b/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
@@ -43,6 +43,7 @@
     const characterSleep = () => {
         // clear all fatigue
         character.inventory = character.inventory.filter(item => item.type !== 'fatigue');
+        characterRest();
         $modifyCharacter();
     }
 
@@ -56,6 +57,7 @@
         for (const AS in character.ability_scores) {
             character.ability_scores[AS].current = character.ability_scores[AS].max;
         }
+        characterSleep();
         $modifyCharacter();
     }
 

--- a/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
+++ b/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
@@ -9,7 +9,6 @@
     import InPlaceEditBox from "../../../InPlaceEditBox.svelte";
     import RowBoxWithLabel from "../../../RowBoxWithLabel.svelte";
     import SimpleButton from "../../../SimpleButton.svelte";
-    import SimpleAccordionDetail from "../../SimpleAccordionDetail.svelte";
     import Armor from "../Components/Armor.svelte";
     import CharSheetMenu from "../Components/CharSheetMenu.svelte";
     import HpBox from "../Components/HpBox.svelte";
@@ -81,10 +80,20 @@
         return stackable <= unstackable ? 0 : stackable - unstackable;
     }
 
-    $: filledSlotsCount = character.inventory.reduce(
-        (acc, item) => acc + (item.bulky ? 2 : item.stacks ? 0 : 1),
-        0
-    ) + stackItems();
+    const checkOverEncumbered = () => {
+        if (filledSlotsCount >= ~~character.slots) {
+            character.hp = "0";
+        }
+    }
+
+    let filledSlotsCount: number = 0;
+    $: {
+        filledSlotsCount = character.inventory.reduce(
+            (acc, item) => acc + (item.bulky ? 2 : item.stacks ? 0 : 1),
+            0
+        ) + stackItems();
+        checkOverEncumbered();
+    }
 
 </script>
 

--- a/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
+++ b/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
@@ -73,10 +73,16 @@
         $sendSkillCheck(0, `${AS} save | success <= ${character.ability_scores[AS].current}`, `${character.name.split(' ')[0]}`, '-', 'd20', '', '', 'roll-under');
     }
 
+    const stackItems = () => {
+        let stackable = character.inventory.filter((item) => item.stacks).length;
+        let unstackable = character.inventory.length - stackable;
+        return stackable <= unstackable ? 0 : stackable - unstackable;
+    }
+
     $: filledSlotsCount = character.inventory.reduce(
-        (acc, item) => acc + (item.stacks ? 0 : item.bulky ? 2 : 1),
+        (acc, item) => acc + (item.bulky ? 2 : item.stacks ? 0 : 1),
         0
-    );
+    ) + stackItems();
 
 </script>
 
@@ -113,7 +119,7 @@
             <InPlaceEdit bind:value={character.slots} editWidth='2em' editHeight='2em' on:submit={() => $modifyCharacter()}/>
         </RowBoxWithLabel>
         <RowBoxWithLabel label='Filled slots' wantBorder={filledSlotsCount >= ~~character.slots}>
-            {filledSlotsCount}
+            {filledSlotsCount > ~~character.slots ? ~~character.slots : filledSlotsCount }
         </RowBoxWithLabel>
     </div>
 


### PR DESCRIPTION
## Issue Description

- Stackable items aren't actually weightless. They should take over an existing item's slot. If you add a stackable item and there's no free existing item to stack it on, it should take up 1 slot.
- Filled slots should not exceed the number of available slots. Even if you had 14 items and 10 slots, you technically only fill 10 slots.
- If all inventory slots are filled, reduce HP to 0.
- Resting for a week should sleep, and sleeping should quick rest.

## Implementation

- Stacks use up an existing slot of another item once. If there are no available slots, stacks count as 1.
- Check if filled slots > character slots. If so, use character slots.
- Check over-encumbered state after calculating filled slots.
- Chain resting methods together.

