### PR TITLE
Add optional gear packages from Cairn

### DIFF
--- a/src/client/src/components/Game/CharacterSheet/Cairn/CreateRandomSheetCairn.svelte
+++ b/src/client/src/components/Game/CharacterSheet/Cairn/CreateRandomSheetCairn.svelte
@@ -15,47 +15,6 @@
     import SimpleIconButton from "../../../SimpleIconButton.svelte";
     import SimpleSegmentChoice from "../../../SimpleSegmentChoice.svelte";
 
-    // TODO: replace with actual gear packages
-    const MOCK_GEAR: { name: string, items: Partial<ItemCairn>[]}[]  = [
-        {
-            name: 'Cleric',
-            items: [
-                {
-                    name: 'War Hammer (d10, bulky)',
-                    type: 'weapon',
-                    damage: 'd10',
-                    bulky: true
-                },
-                {
-                    name: 'Chainmail (2 Armor, bulky)',
-                    type: 'armor',
-                    armor: '2',
-                    bulky: true
-                },
-                {
-                    name: 'Gauntlets (+1 Armor)',
-                    type: 'armor',
-                    armor: '+1',
-                    bulky: false
-                },
-                {
-                    name: 'Cleansing Blade (d6)',
-                    type: 'weapon',
-                    damage: 'd6',
-                    bulky: false
-                },
-                {
-                    name: 'Holy Symbol',
-                    type: 'item'
-                },
-                {
-                    name: 'Cloak of the Order',
-                    type: 'item'
-                }
-            ]
-        }
-    ]
-
     const cairn = $user.gameData.cairn;
 
     export let character: Partial<CharacterCairn> = {};
@@ -243,9 +202,9 @@
         else if (genOptions.other.selectedOption === 'blank') {
             Object.assign(newStats, {
                 age: '',
-                hp: '', 
+                hp: '',
                 hp_max: '',
-                coins: { 
+                coins: {
                     gp: '',
                     sp: '',
                     cp: ''
@@ -343,7 +302,7 @@
             genOptions[optionKey].selectedOption = undefined;
             genOptions[optionKey].custom = genOptions[optionKey].custom ? '' : undefined;
         }
-             
+
         randomSheetDialogOpen = true;
     }
 
@@ -388,8 +347,8 @@
                                     </div>
                                     <SimpleIconButton icon="mdi:autorenew" width="1.5em" onClickFn={() => genOptions[optionKey].selectedOption = undefined} />
                                 {:else if genOptions[optionKey].selectedOption === 'gear'}
-                                    <Svelecte 
-                                        options={MOCK_GEAR}
+                                    <Svelecte
+                                        options={cairn.gear_packages}
                                         valueAsObject
                                         placeholder='Gear Package'
                                         bind:value={genOptions.inventory.gearPackage}
@@ -410,7 +369,7 @@
                     {/if}
                 {:else}
                     <div class="random-gen-rules">
-                        
+
                     </div>
                 {/if}
             </dialog-content>

--- a/src/enum/cairn/ARMORS.ts
+++ b/src/enum/cairn/ARMORS.ts
@@ -17,7 +17,6 @@ export class ArmorCairn {
 export const ARMORS: Record<string, Partial<ItemCairn>> = {
     ... new ArmorCairn({ name: 'Shield', armor: '+1' }).record,
     ... new ArmorCairn({ name: 'Helmet', armor: '+1' }).record,
-    ... new ArmorCairn({ name: 'Gauntlets', armor: '+1' }).record,
     ... new ArmorCairn({ name: 'Gambeson', armor: '+1' }).record,
     ... new ArmorCairn({ name: 'Brigandine', armor: '1', bulky: true }).record,
     ... new ArmorCairn({ name: 'Chainmail', armor: '2', bulky: true }).record,

--- a/src/enum/cairn/CAIRN_DATA.ts
+++ b/src/enum/cairn/CAIRN_DATA.ts
@@ -1,6 +1,7 @@
 import { ARMORS } from "./ARMORS";
 import { BACKGROUNDS } from "./BACKGROUNDS";
 import { GEAR } from "./GEAR";
+import { GEAR_PACKAGES } from "./GEAR_PACKAGES";
 import { NAMES_FEMALE, NAMES_MALE, SURNAMES } from "./NAMES_CAIRN";
 import { RULES_SUMMARY } from "./RULES_SUMMARY";
 import { SCARS } from "./SCARS";
@@ -11,6 +12,7 @@ import { TRINKETS } from "./TRINKETS";
 
 export const CAIRN_DATA = {
     gear: GEAR,
+    gear_packages: GEAR_PACKAGES,
     tools: TOOLS,
     trinkets: TRINKETS,
     spellbooks: SPELLBOOKS,

--- a/src/enum/cairn/GEAR_PACKAGES.ts
+++ b/src/enum/cairn/GEAR_PACKAGES.ts
@@ -1,0 +1,144 @@
+import { ItemCairn } from "../../interfaces/CharacterCairn"
+import { ArmorCairn, ARMORS } from "./ARMORS"
+import { WeaponCairn, WEAPONS } from "./WEAPONS"
+import { SPELLBOOKS } from "./SPELLBOOKS"
+
+const createItem = ({ name, description, bulky, stacks }: {
+    name: string,
+    description?: string,
+    bulky?: boolean,
+    stacks?: boolean,
+}
+): ItemCairn => {
+    return { name: name, type: 'item', description: description, bulky, stacks: stacks, };
+}
+
+const getRandomSpellbook = (): ItemCairn => {
+    const spellbook = SPELLBOOKS[Math.floor(Math.random() * SPELLBOOKS.length)];
+    return { name: spellbook.name, type: 'spellbook', description: spellbook.description };
+}
+
+const getCharmOrDetectSpellbook = (): ItemCairn => {
+    if ((Math.floor(Math.random() * 2) == 0)) {
+        const charm = SPELLBOOKS[13];
+        return { name: charm.name, type: 'spellbook', description: charm.description };
+    } else {
+        const detect = SPELLBOOKS[21];
+        return { name: detect.name, type: 'spellbook', description: detect.description };
+    }
+}
+
+export const GEAR_PACKAGES: { name: string, items: Partial<ItemCairn>[] }[] = [
+    {
+        name: 'Cleric',
+        items: [
+            WEAPONS["War Hammer"],
+            ARMORS["Chainmail"],
+            new ArmorCairn({ name: "Gauntlets", armor: "+1" }).getItem(),
+            new WeaponCairn({ name: "Cleansing Blade", damage: "d6" }).getItem(),
+            createItem({ name: "Holy Symbol", description: "Ward once per day" }),
+            createItem({ name: "Cloak of the Order" })
+        ],
+    },
+    {
+        name: "Dowser",
+        items: [
+            new WeaponCairn({ name: "Sickle", damage: "d6" }).getItem(),
+            new ArmorCairn({ name: "Patchwork Doublet", armor: "+1" }).getItem(),
+            createItem({ name: "Dowsing Rod" }),
+            createItem({ name: "Eyestone", description: "Sense if placed in fresh water" }),
+            createItem({ name: "Worn Map" }),
+            createItem({ name: "Spyglass" })
+        ],
+    },
+    {
+        name: "Dwarf",
+        items: [
+            new WeaponCairn({ name: "Prickly Root", damage: "d6" }).getItem(),
+            new ArmorCairn({ name: "Pinecone Lattice", armor: "1" }).getItem(),
+            createItem({ name: "Trowel" }),
+            createItem({ name: "Jar of Forest Ants" }),
+            createItem({ name: "Poisonous Mushroom" }),
+            createItem({ name: "Hand Drill" })
+        ],
+    },
+    {
+        name: "Elf",
+        items: [
+            new WeaponCairn({ name: "Elegant Sword", damage: "d8" }).getItem(),
+            new WeaponCairn({ name: "Recurve Bow", damage: "d8" }).getItem(),
+            new ArmorCairn({ name: "Gilt Clothing", armor: "1" }).getItem(),
+            getCharmOrDetectSpellbook(),
+            createItem({ name: "Golden Flute" }),
+            createItem({ name: "Air Bladder" })
+        ],
+    },
+    {
+        name: "Fighter",
+        items: [
+            new WeaponCairn({ name: "Glaive", damage: "d10", bulky: true }).getItem(),
+            new WeaponCairn({ name: "Scimitar", damage: "d8" }).getItem(),
+            new WeaponCairn({ name: "Shortsword", damage: "d6" }).getItem(),
+            new WeaponCairn({ name: "Shortsword", damage: "d6" }).getItem(),
+            createItem({ name: "Tobacco Pouch & Pipe" }),
+            createItem({ name: "Dice Set", stacks: true })
+        ],
+    },
+    {
+        name: "Friar",
+        items: [
+            new ArmorCairn({ name: "Scepter", armor: "d6" }).getItem(),
+            new ArmorCairn({ name: "Deceptive Robes", armor: "+1" }).getItem(),
+            createItem({ name: "Censer & Holy Water" }),
+            createItem({ name: "Jug of Honey Wine" }),
+            createItem({ name: "Folk Songbook" }),
+            createItem({ name: "Cart", description: "+4 slots", bulky: true }) // TODO: We should add logic to automatically increase slots
+        ],
+    },
+    {
+        name: "Knight",
+        items: [
+            new WeaponCairn({ name: "Longsword", damage: "d10", bulky: true }).getItem(),
+            ARMORS["Chainmail"],
+            ARMORS["Helmet"],
+            createItem({ name: "Heraldic Cape" }),
+            createItem({ name: "Manacles" }),
+            createItem({ name: "Fine Rope" })
+        ],
+    },
+    {
+        name: "Magic User",
+        items: [
+            new WeaponCairn({ name: "Fizzled Staff", damage: "d8", bulky: true }).getItem(),
+            WEAPONS["Dagger"],
+            getRandomSpellbook(),
+            getRandomSpellbook(),
+            createItem({ name: "Ragged Clothing", description: "hidden pockets" }),
+            createItem({ name: "Leycap", description: "1 use. Anyone ingesting this green-flecked mushroom loses a Fatigue, but is then required to make a WIL save to avoid its addictive properties. A fail leaves the PC deprived and unable to focus until they can eat another leycap, providing only a brief reprieve from the addiction." }),
+            createItem({ name: "Leycap", description: "1 use. Anyone ingesting this green-flecked mushroom loses a Fatigue, but is then required to make a WIL save to avoid its addictive properties. A fail leaves the PC deprived and unable to focus until they can eat another leycap, providing only a brief reprieve from the addiction." })
+        ],
+    },
+    {
+        name: "Thief",
+        items: [
+            new WeaponCairn({ name: "Two daggers", damage: "d6+d8" }).getItem(),
+            new ArmorCairn({ name: "Hooded Jerkin", armor: "1" }).getItem(),
+            createItem({ name: "Lockpick" }),
+            createItem({ name: "Caltrops" }),
+            createItem({ name: "Grappling Hook" }),
+            createItem({ name: "Metal File", stacks: true })
+        ],
+    },
+    {
+        name: "Ranger",
+        items: [
+            new WeaponCairn({ name: "Longbow", damage: "d8", bulky: true }).getItem(), // Stronger than normal longbow d6
+            new WeaponCairn({ name: "Hatchet", damage: "d6" }).getItem(),
+            new ArmorCairn({ name: "Padded Leathers", armor: "1" }).getItem(),
+            createItem({ name: "Large Trap" }),
+            //"Bloodhound | 2 HP, 12 DEX, bite (d6)", // TODO, how to do companions?
+            createItem({ name: "Thundering Horn" })
+        ],
+    }
+]
+

--- a/src/enum/cairn/WEAPONS.ts
+++ b/src/enum/cairn/WEAPONS.ts
@@ -1,0 +1,31 @@
+import { ItemCairn } from "../../interfaces/CharacterCairn";
+
+export class WeaponCairn {
+    public record: Record<string, Partial<ItemCairn>>;
+
+    constructor({ name, damage, bulky }: { name: string, damage: string, bulky?: boolean }) {
+        const prettyName = `${name} (${damage}${bulky ? ', bulky' : ''})`;
+        this.record = { [name]: { name: prettyName, type: 'weapon', damage: damage, bulky} }
+        return this;
+    }
+
+    public getItem() {
+        return this.record[Object.keys(this.record)[0]];
+    }
+}
+
+export const WEAPONS: Record<string, Partial<ItemCairn>> = {
+    ... new WeaponCairn({ name: "Dagger", damage: "d6"}).record,
+    ... new WeaponCairn({ name: "Cudgel", damage: "d6"}).record,
+    ... new WeaponCairn({ name: "Staff", damage: "d6"}).record,
+    ... new WeaponCairn({ name: "Sword", damage: "d8"}).record,
+    ... new WeaponCairn({ name: "Mace", damage: "d8"}).record,
+    ... new WeaponCairn({ name: "Axe", damage: "d8"}).record,
+    ... new WeaponCairn({ name: "Longbow", damage: "d6", bulky: true}).record,
+    ... new WeaponCairn({ name: "Crossbow", damage: "d6", bulky: true}).record,
+    ... new WeaponCairn({ name: "Sling", damage: "d4"}).record,
+    ... new WeaponCairn({ name: "Halberd", damage: "d10", bulky: true}).record,
+    ... new WeaponCairn({ name: "War Hammer", damage: "d10", bulky: true}).record,
+    ... new WeaponCairn({ name: "Battleaxe", damage: "d10", bulky: true}).record,
+
+}


### PR DESCRIPTION
Fixes #83 

- New GEAR_PACKAGES contains optional class-like gear packages
  - Items are generated on the fly, but existing weapons and armors from starting packages are reused
- Export createArmor for use in gear package generation
- Import GEAR_PACKAGES into CAIRN_DATA

Some unknowns:

- Does the elf spell "Detect" refer to "Detect Magic"?
- Do elves get to choose between "Charm" or "Detect"? Currently, this is randomly 50/50 picked.
- Companions like the ranger's bloodhound shouldn't be considered items, but NPC companions. How should we implement this?
- The ranger's longbow appears to be stronger (d8) than usual (d6)
- The Cart item adds +4 slots, but this requires the user to manually adjust the Total Slots themselves. We could add logic to detect "+x slots" in names and automatically increase the total slots.
