### PR TITLE
Add slotless items

### DIFF
--- a/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
+++ b/src/client/src/components/Game/CharacterSheet/Cairn/CharacterSheetCoreCairn.svelte
@@ -76,7 +76,7 @@
 
     const stackItems = () => {
         let stackable = character.inventory.filter((item) => item.stacks).length;
-        let unstackable = character.inventory.length - stackable;
+        let unstackable = character.inventory.filter((item) => !item.stacks && !item.slotless).length;
         return stackable <= unstackable ? 0 : stackable - unstackable;
     }
 
@@ -89,7 +89,7 @@
     let filledSlotsCount: number = 0;
     $: {
         filledSlotsCount = character.inventory.reduce(
-            (acc, item) => acc + (item.bulky ? 2 : item.stacks ? 0 : 1),
+            (acc, item) => acc + (item.bulky ? 2 : item.stacks || item.slotless ? 0 : 1),
             0
         ) + stackItems();
         checkOverEncumbered();

--- a/src/client/src/components/Game/CharacterSheet/Cairn/ItemDetailCairn.svelte
+++ b/src/client/src/components/Game/CharacterSheet/Cairn/ItemDetailCairn.svelte
@@ -41,6 +41,23 @@
         }
     }
 
+    const checkItemState = () => {
+        const STATE0 = !item.bulky && !item.stacks && !item.slotless
+        const STATE1 = item.bulky && !item.stacks && !item.slotless
+        const STATE2 = !item.bulky && item.stacks && !item.slotless
+        if (STATE0) {
+            item.bulky = true
+        } else if (STATE1) {
+            item.bulky = false;
+            item.stacks = true;
+        } else if (STATE2) {
+            item.stacks = false;
+            item.slotless = true;
+        } else {
+            item.slotless = false;
+        }
+    }
+
 </script>
 
 <box class="item-main-container {item.type === "fatigue" ? 'striped' : ''}">
@@ -66,8 +83,8 @@
                 <InPlaceEdit bind:value={item.name} editWidth={editWidth} editHeight={editHeight} on:submit={() => onSubmitFn()}/>
             </div>
             <div class="item-bulky">
-                <sendable on:click={() => {(!item.stacks && !item.bulky) ? item.bulky = true : (!item.stacks && item.bulky) ? (item.stacks = true, item.bulky = false) : (item.stacks = false, item.bulky = false); onSubmitFn();}} on:keyup={() => {}}>
-                    <Icon class="medi-icon" icon="{item.stacks ? 'mdi:card-multiple' : item.bulky ? 'mdi:weight': 'mdi:feather'}" />
+                <sendable on:click={() => {checkItemState(); onSubmitFn();}} on:keyup={() => {}}>
+                    <Icon class="medi-icon" icon="{item.stacks ? 'mdi:card-multiple' : item.bulky ? 'mdi:weight': item.slotless ? 'mdi:checkbox-blank-off-outline' : 'mdi:feather'}" />
                 </sendable>
             </div>
             <sendable class="item-menu" on:click={() => { isOpen = !isOpen }} on:keyup={() => {}}>

--- a/src/client/src/interfaces/Cairn/CharacterCairn.ts
+++ b/src/client/src/interfaces/Cairn/CharacterCairn.ts
@@ -23,6 +23,7 @@ export interface ItemCairn {
     type: string,
     bulky?: boolean,
     stacks?: boolean,
+    slotless?: boolean,
     damage?: string,
     armor?: string,
     description?: string


### PR DESCRIPTION
Fixes #91.

Uses state machine to cycle through 4 states.
I didn't add logic for items that add slot. Easier to let the user manage for now.